### PR TITLE
Add user metadata to authentication process

### DIFF
--- a/vertx-auth-ldap/pom.xml
+++ b/vertx-auth-ldap/pom.xml
@@ -15,6 +15,9 @@
     <version>4.4.1-SNAPSHOT</version>
   </parent>
 
+  <!-- Override for our Jar -->
+  <version>4.4.0-ucla</version>
+
   <modelVersion>4.0.0</modelVersion>
 
   <properties>

--- a/vertx-auth-ldap/src/main/generated/io/vertx/ext/auth/ldap/LdapAuthenticationOptionsConverter.java
+++ b/vertx-auth-ldap/src/main/generated/io/vertx/ext/auth/ldap/LdapAuthenticationOptionsConverter.java
@@ -30,9 +30,24 @@ public class LdapAuthenticationOptionsConverter {
             obj.setAuthenticationQuery((String)member.getValue());
           }
           break;
+        case "filterQuery":
+          if (member.getValue() instanceof String) {
+            obj.setFilterQuery((String)member.getValue());
+          }
+          break;
         case "referral":
           if (member.getValue() instanceof String) {
             obj.setReferral((String)member.getValue());
+          }
+          break;
+        case "returningAttributes":
+          if (member.getValue() instanceof JsonArray) {
+            java.util.ArrayList<java.lang.String> list =  new java.util.ArrayList<>();
+            ((Iterable<Object>)member.getValue()).forEach( item -> {
+              if (item instanceof String)
+                list.add((String)item);
+            });
+            obj.setReturningAttributes(list);
           }
           break;
         case "url":
@@ -55,8 +70,16 @@ public class LdapAuthenticationOptionsConverter {
     if (obj.getAuthenticationQuery() != null) {
       json.put("authenticationQuery", obj.getAuthenticationQuery());
     }
+    if (obj.getFilterQuery() != null) {
+      json.put("filterQuery", obj.getFilterQuery());
+    }
     if (obj.getReferral() != null) {
       json.put("referral", obj.getReferral());
+    }
+    if (obj.getReturningAttributes() != null) {
+      JsonArray array = new JsonArray();
+      obj.getReturningAttributes().forEach(item -> array.add(item));
+      json.put("returningAttributes", array);
     }
     if (obj.getUrl() != null) {
       json.put("url", obj.getUrl());

--- a/vertx-auth-ldap/src/main/java/io/vertx/ext/auth/ldap/LdapAuthentication.java
+++ b/vertx-auth-ldap/src/main/java/io/vertx/ext/auth/ldap/LdapAuthentication.java
@@ -28,9 +28,9 @@ public interface LdapAuthentication extends AuthenticationProvider {
   /**
    * Create a LDAP authentication provider
    *
-   * @param vertx  the Vert.x instance
-   * @param options  the ldap options
-   * @return  the authentication provider
+   * @param vertx The Vert.x instance
+   * @param options The ldap options
+   * @return The authentication provider
    */
   static LdapAuthentication create(Vertx vertx, LdapAuthenticationOptions options) {
     return new LdapAuthenticationImpl(vertx, options);

--- a/vertx-auth-ldap/src/main/java/io/vertx/ext/auth/ldap/LdapAuthenticationOptions.java
+++ b/vertx-auth-ldap/src/main/java/io/vertx/ext/auth/ldap/LdapAuthenticationOptions.java
@@ -12,11 +12,13 @@
  ********************************************************************************/
 package io.vertx.ext.auth.ldap;
 
+import java.util.List;
+
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 
 /**
- * Ldap auth configuration options
+ * LDAP auth configuration options.
  *
  * @author <a href="mail://stephane.bastian.dev@gmail.com">Stephane Bastian</a>
  */
@@ -27,6 +29,8 @@ public class LdapAuthenticationOptions {
   private String referral;
   private String url;
   private String authenticationQuery;
+  private String filterQuery;
+  private List<String> filterAttributes;
 
   public LdapAuthenticationOptions() {
   }
@@ -53,8 +57,27 @@ public class LdapAuthenticationOptions {
   }
 
   /**
-   * sets the authentication mechanism. default to 'simple' if not set
-   * 
+   * Gets a filter query that's used to lookup metadata about the authenticated user.
+   *
+   * @return A query that's used to filter a search to a single user
+   */
+  public String getFilterQuery() {
+    return filterQuery;
+  }
+
+  /**
+   * Gets the list of attributes that should be returned from a filtered query. These are used to populate principal
+   * metadata in the {@link User} object.
+   *
+   * @return A list of attribute names
+   */
+  public List<String> getReturningAttributes() {
+    return filterAttributes;
+  }
+
+  /**
+   * Sets the authentication mechanism. default to 'simple' if not set
+   *
    * @param authenticationMechanism
    * @return a reference to this, so the API can be used fluently
    */
@@ -64,8 +87,8 @@ public class LdapAuthenticationOptions {
   }
 
   /**
-   * Set the referral property. Default to 'follow' if not set
-   * 
+   * Sets the referral property. Default to 'follow' if not set
+   *
    * @param referral the referral
    * @return a reference to this, so the API can be used fluently
    */
@@ -75,9 +98,8 @@ public class LdapAuthenticationOptions {
   }
 
   /**
-   * Set the url to the LDAP server. The url must start with `ldap://` and a port
-   * must be specified.
-   * 
+   * Sets the url to the LDAP server. The url must start with `ldap://` and a port must be specified.
+   *
    * @param url the url to the server
    * @return a reference to this, so the API can be used fluently
    */
@@ -87,11 +109,10 @@ public class LdapAuthenticationOptions {
   }
 
   /**
-   * Set the query to use to authenticate a user. This is used to determine the
-   * actual lookup to use when looking up a user with a particular id. An example
-   * is `uid={0},ou=users,dc=foo,dc=com` - Note that the element `{0}` is
+   * Sets the query to use to authenticate a user. This is used to determine the actual lookup to use when looking up a
+   * user with a particular id. An example is `uid={0},ou=users,dc=foo,dc=com` - Note that the element `{0}` is
    * substituted with the user id to create the actual lookup.
-   * 
+   *
    * @param authenticationQuery
    * @return a reference to this, so the API can be used fluently
    */
@@ -100,4 +121,26 @@ public class LdapAuthenticationOptions {
     return this;
   }
 
+  /**
+   * Sets the filter query to record additional information about a user. This is used in conjunction with the
+   * authentication query. The same pattern for inserting the user id may also be used with this query.
+   *
+   * @param filterQuery
+   * @return a reference to this, so the API can be used fluently
+   */
+  public LdapAuthenticationOptions setFilterQuery(String filterQuery) {
+    this.filterQuery = filterQuery;
+    return this;
+  }
+
+  /**
+   * Sets the attributes returned by a filter query of the user.
+   *
+   * @param filterAttributes
+   * @return a reference to this, so the API can be used fluently
+   */
+  public LdapAuthenticationOptions setReturningAttributes(List<String> filterAttributes) {
+    this.filterAttributes = filterAttributes;
+    return this;
+  }
 }

--- a/vertx-auth-ldap/src/main/java/io/vertx/ext/auth/ldap/impl/LdapAuthenticationImpl.java
+++ b/vertx-auth-ldap/src/main/java/io/vertx/ext/auth/ldap/impl/LdapAuthenticationImpl.java
@@ -27,6 +27,8 @@ import javax.naming.ldap.LdapContext;
 
 import io.vertx.core.*;
 import io.vertx.core.impl.VertxInternal;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
@@ -41,6 +43,9 @@ import io.vertx.ext.auth.ldap.LdapAuthenticationOptions;
  * @author <a href="mail://stephane.bastian.dev@gmail.com">Stephane Bastian</a>
  */
 public class LdapAuthenticationImpl implements LdapAuthentication {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LdapAuthenticationImpl.class);
+
   private static final String SIMPLE_AUTHENTICATION_MECHANISM = "simple";
   private static final String FOLLOW_REFERRAL = "follow";
 
@@ -148,6 +153,10 @@ public class LdapAuthenticationImpl implements LdapAuthentication {
               } else if (attributeCount == 1) {
                 metadata.put(id, attribute.get(0));
               }
+            }
+
+            if (searchResults.hasMore()) {
+              LOG.warn("LDAP user filter returns more than one user");
             }
           }
 

--- a/vertx-auth-ldap/src/main/java/io/vertx/ext/auth/ldap/impl/LdapAuthenticationImpl.java
+++ b/vertx-auth-ldap/src/main/java/io/vertx/ext/auth/ldap/impl/LdapAuthenticationImpl.java
@@ -12,12 +12,16 @@
  ********************************************************************************/
 package io.vertx.ext.auth.ldap.impl;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Objects;
 
 import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
 import javax.naming.ldap.InitialLdapContext;
 import javax.naming.ldap.LdapContext;
 
@@ -32,6 +36,8 @@ import io.vertx.ext.auth.ldap.LdapAuthentication;
 import io.vertx.ext.auth.ldap.LdapAuthenticationOptions;
 
 /**
+ * An implementation of {@link LdapAuthentication}.
+ *
  * @author <a href="mail://stephane.bastian.dev@gmail.com">Stephane Bastian</a>
  */
 public class LdapAuthenticationImpl implements LdapAuthentication {
@@ -41,6 +47,12 @@ public class LdapAuthenticationImpl implements LdapAuthentication {
   private final Vertx vertx;
   private final LdapAuthenticationOptions authenticationOptions;
 
+  /**
+   * Creates a new instance of the LdapAuthentication implementation.
+   *
+   * @param vertx                 A Vert.x instance
+   * @param authenticationOptions Authentication options
+   */
   public LdapAuthenticationImpl(Vertx vertx, LdapAuthenticationOptions authenticationOptions) {
     this.vertx = Objects.requireNonNull(vertx);
     this.authenticationOptions = Objects.requireNonNull(authenticationOptions);
@@ -48,61 +60,102 @@ public class LdapAuthenticationImpl implements LdapAuthentication {
 
   @Override
   public void authenticate(JsonObject credentials, Handler<AsyncResult<User>> resultHandler) {
-    authenticate(credentials)
-      .onComplete(resultHandler);
+    authenticate(credentials).onComplete(resultHandler);
   }
 
   @Override
-  public Future<io.vertx.ext.auth.User> authenticate(JsonObject credentials) {
+  public Future<User> authenticate(JsonObject credentials) {
     return authenticate(new UsernamePasswordCredentials(credentials));
   }
 
   @Override
-  public Future<io.vertx.ext.auth.User> authenticate(Credentials credentials) {
+  public Future<User> authenticate(Credentials credentials) {
     final UsernamePasswordCredentials authInfo;
+
     try {
       authInfo = (UsernamePasswordCredentials) credentials;
-      authInfo.checkValid(null);
+      authInfo.checkValid(null); // This checks for nulls
     } catch (RuntimeException e) {
       return Future.failedFuture(e);
     }
 
-    String ldapPrincipal = getLdapPrincipal(authInfo.getUsername());
-    return createLdapContext(ldapPrincipal, authInfo.getPassword())
-      .compose(ldapContext -> {
-        User user = User.fromName(authInfo.getUsername());
-        // metadata "amr"
-        user.principal().put("amr", Collections.singletonList("pwd"));
-        return Future.succeededFuture(user);
-      });
+    return getUser(getLdapPrincipal(authInfo.getUsername()), authInfo);
   }
 
-  private Future<LdapContext> createLdapContext(String principal, String credential) {
+  /**
+   * Gets an authenticated user from an LDAP source.
+   *
+   * @param principal   The user principal that's authenticated
+   * @param credentials The username and password of the user
+   * @return A user that's been authenticated against the LDAP source
+   */
+  private Future<User> getUser(String principal, UsernamePasswordCredentials credentials) {
     Hashtable<String, Object> environment = new Hashtable<>();
-    // set the initial cntext factory
+    Promise<User> promise = ((VertxInternal) vertx).promise();
+
     environment.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-    // set the url
     environment.put(Context.PROVIDER_URL, authenticationOptions.getUrl());
 
     if (principal != null) {
       environment.put(Context.SECURITY_PRINCIPAL, principal);
     }
-    if (credential != null) {
-      environment.put(Context.SECURITY_CREDENTIALS, credential);
+
+    if (credentials != null) {
+      environment.put(Context.SECURITY_CREDENTIALS, credentials.getPassword());
     }
-    if (authenticationOptions.getAuthenticationMechanism() == null && (principal != null || credential != null)) {
+
+    if (authenticationOptions.getAuthenticationMechanism() == null && (principal != null || credentials != null)) {
       environment.put(Context.SECURITY_AUTHENTICATION, SIMPLE_AUTHENTICATION_MECHANISM);
     }
-    // referral
-    environment.put(Context.REFERRAL,
-      authenticationOptions.getReferral() == null ? FOLLOW_REFERRAL : authenticationOptions.getReferral());
 
-    Promise<LdapContext> promise = ((VertxInternal) vertx).promise();
+    environment.put(Context.REFERRAL,
+        authenticationOptions.getReferral() == null ? FOLLOW_REFERRAL : authenticationOptions.getReferral());
 
     vertx.executeBlocking(blockingResult -> {
       try {
         LdapContext context = new InitialLdapContext(environment, null);
-        blockingResult.complete(context);
+        User user = User.fromName(credentials.getUsername());
+
+        // Authentication method metadata
+        user.principal().put("amr", Collections.singletonList("pwd"));
+
+        // If filter query is set, we want to store additional user metadata which can
+        // be used later to authorize
+        if (authenticationOptions.getFilterQuery() != null) {
+          String filter = getFilterQuery(credentials.getUsername());
+          SearchControls searchControls = getSearchControls();
+          NamingEnumeration<SearchResult> searchResults = context.search(principal, filter, searchControls);
+
+          if (searchResults.hasMore()) {
+            SearchResult result = searchResults.next();
+            NamingEnumeration<? extends Attribute> attributes = result.getAttributes().getAll();
+            JsonObject metadata = user.principal();
+
+            // If attributes are returned, store them in our User object
+            while (attributes.hasMore()) {
+              Attribute attribute = attributes.next();
+              int attributeCount = attribute.size();
+              String id = attribute.getID();
+
+              if (attributeCount > 1) {
+                JsonArray values = new JsonArray(); // Can store nulls
+
+                for (int index = 0; index < attributeCount; index++) {
+                  values.add(attribute.get(index)); // Might be a null
+                }
+
+                metadata.put(id, values);
+              } else if (attributeCount == 1) {
+                metadata.put(id, attribute.get(0));
+              }
+            }
+          }
+
+          searchResults.close();
+        }
+
+        context.close();
+        blockingResult.complete(user);
       } catch (Throwable t) {
         blockingResult.fail(t);
       }
@@ -111,8 +164,43 @@ public class LdapAuthenticationImpl implements LdapAuthentication {
     return promise.future();
   }
 
+  /**
+   * Gets the search controls that should be used when searching for user metadata.
+   *
+   * @return Search controls used when searching for user metadata
+   */
+  private SearchControls getSearchControls() {
+    List<String> returningAttributes = authenticationOptions.getReturningAttributes();
+    SearchControls searchControls = new SearchControls();
+
+    // Support searching subtrees
+    searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+
+    // Optionally, restrict attributes returned
+    if (returningAttributes != null) {
+      searchControls.setReturningAttributes(returningAttributes.toArray(new String[0]));
+    }
+
+    return searchControls;
+  }
+
+  /**
+   * Gets the user principal with the supplied username added.
+   *
+   * @param principal A username
+   * @return The complete LDAP principal
+   */
   private String getLdapPrincipal(String principal) {
     return authenticationOptions.getAuthenticationQuery().replace("{0}", principal);
   }
 
+  /**
+   * Gets the filter used for querying the user's additional metadata.
+   *
+   * @param principal A username
+   * @return The complete LDAP filter query
+   */
+  private String getFilterQuery(String principal) {
+    return authenticationOptions.getFilterQuery().replace("{0}", principal);
+  }
 }

--- a/vertx-auth-ldap/src/test/java/io/vertx/ext/auth/ldap/LdapAuthenticationTest.java
+++ b/vertx-auth-ldap/src/test/java/io/vertx/ext/auth/ldap/LdapAuthenticationTest.java
@@ -16,6 +16,10 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.directory.server.annotations.CreateLdapServer;
 import org.apache.directory.server.annotations.CreateTransport;
 import org.apache.directory.server.core.annotations.ApplyLdifFiles;
@@ -27,12 +31,17 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import org.junit.runner.RunWith;
 
-@CreateDS(name = "myDS", partitions = {@CreatePartition(name = "test", suffix = "dc=myorg,dc=com")})
-@CreateLdapServer(transports = {@CreateTransport(protocol = "LDAP", address = "localhost")})
-@ApplyLdifFiles({"ldap.ldif"})
+/**
+ * Tests of {@link LdapAuthentication}.
+ */
+@CreateDS(name = "myDS", partitions = { @CreatePartition(name = "test", suffix = "dc=myorg,dc=com") })
+@CreateLdapServer(transports = { @CreateTransport(protocol = "LDAP", address = "localhost") })
+@ApplyLdifFiles({ "ldap.ldif" })
 @RunWith(VertxUnitRunner.class)
 public class LdapAuthenticationTest {
 
@@ -41,51 +50,101 @@ public class LdapAuthenticationTest {
 
   @ClassRule
   public static CreateLdapServerRule serverRule = new CreateLdapServerRule();
-  private LdapAuthentication authProvider;
 
+  private LdapAuthentication authProvider;
+  private LdapAuthenticationOptions ldapOptions;
+
+  /**
+   * Tests that a user with the correct username and password authenticates.
+   *
+   * @param should A testing context
+   */
   @Test
   public void testSimpleAuthenticate(TestContext should) {
     final Async test = should.async();
 
     UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("tim", "sausages");
-    authProvider.authenticate(credentials)
-      .onFailure(should::fail)
-      .onSuccess(user -> {
-        should.assertNotNull(user);
-        test.complete();
-      });
+    authProvider.authenticate(credentials).onFailure(should::fail).onSuccess(user -> {
+      should.assertNotNull(user);
+      test.complete();
+    });
   }
 
+  /**
+   * Tests that a user with the wrong password fails to authenticate.
+   *
+   * @param should A testing context
+   */
   @Test
   public void testSimpleAuthenticateFailWrongPassword(TestContext should) {
     final Async test = should.async();
 
     UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("tim", "wrongpassword");
-    authProvider.authenticate(credentials)
-      .onSuccess(user -> should.fail("Should have failed"))
-      .onFailure(thr -> {
-        should.assertNotNull(thr);
-        test.complete();
-      });
+    authProvider.authenticate(credentials).onSuccess(user -> should.fail("Should have failed")).onFailure(thr -> {
+      should.assertNotNull(thr);
+      test.complete();
+    });
   }
 
+  /**
+   * Tests that a user with the wrong username fails to authenticate.
+   *
+   * @param should A testing context
+   */
   @Test
   public void testSimpleAuthenticateFailWrongUser(TestContext should) {
     final Async test = should.async();
     UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("frank", "sausages");
-    authProvider.authenticate(credentials)
-      .onSuccess(user -> should.fail("Should have failed"))
-      .onFailure(thr -> {
-        should.assertNotNull(thr);
-        test.complete();
-      });
+    authProvider.authenticate(credentials).onSuccess(user -> should.fail("Should have failed")).onFailure(thr -> {
+      should.assertNotNull(thr);
+      test.complete();
+    });
   }
 
+  /**
+   * Tests that the user returned from authentication includes LDAP attributes.
+   *
+   * @param should A testing context
+   */
+  @Test
+  public void testAuthenticateWithAttributes(TestContext should) {
+    final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials("tim", "sausages");
+    final List<String> returningAttributes = Arrays.asList("amr", "cn", "sn", "objectclass");
+    final Async test = should.async();
+
+    ldapOptions.setFilterQuery("uid={0}").setReturningAttributes(returningAttributes);
+    authProvider = LdapAuthentication.create(rule.vertx(), ldapOptions);
+    authProvider.authenticate(credentials).onFailure(should::fail).onSuccess(user -> {
+      final JsonObject attributes;
+
+      should.assertNotNull(user);
+      should.assertNotNull(attributes = user.principal());
+
+      // Check that the attributes we request, are returned
+      should.assertEquals("tim", attributes.getString("username"));
+      should.assertEquals("Tim fox", attributes.getString("cn"));
+      should.assertEquals("Ldap", attributes.getString("sn"));
+      should.assertEquals(new JsonArray().add("pwd"), attributes.getJsonArray("amr"));
+      should.assertEquals(new JsonArray().add("top").add("inetOrgPerson").add("person").add("organizationalPerson"),
+          attributes.getJsonArray("objectclass"));
+
+      // Check that the attribute we don't request, aren't returned
+      should.assertNull(attributes.getString("userpassword"));
+
+      // Wrap up test
+      test.complete();
+    });
+  }
+
+  /**
+   * Sets up the testing environment.
+   *
+   * @throws Exception If there is a problem setting up testing environment
+   */
   @Before
   public void setUp() throws Exception {
-    LdapAuthenticationOptions ldapOptions = new LdapAuthenticationOptions().setUrl("ldap://localhost:" + serverRule.getLdapServer().getPort())
-      .setAuthenticationQuery("uid={0},ou=Users,dc=myorg,dc=com");
-
+    ldapOptions = new LdapAuthenticationOptions().setUrl("ldap://localhost:" + serverRule.getLdapServer().getPort())
+        .setAuthenticationQuery("uid={0},ou=Users,dc=myorg,dc=com");
     authProvider = LdapAuthentication.create(rule.vertx(), ldapOptions);
   }
 }


### PR DESCRIPTION
* Add a POM version so we can build locally (they don't use dynamic versioning)
* Add filter query and attributes to client options
* Add optional support for populating principal metadata from LDAP query

Things I didn't do:

* Improve Javadocs across the library (just a few updates)
* Try to make code conform to our style guidelines